### PR TITLE
Add -Wmissing-import-lists and -Wmissing-local-signatures to werrorwolf check

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -119,6 +119,7 @@ local: {
               werrorwolf = {
                 enable = true;
                 packages = config.coding.standards.hydra.haskellPackages;
+                extra-flags = [ "-Wmissing-import-lists -Wmissing-local-signatures" ];
               } // wwpof;
             };
       }


### PR DESCRIPTION
This will forcibly add the flags `-Wmissing-import-lists` and `-Wmissing-local-signatures` to all `-Werror` checks derived from haskell projects regardless of the project settings.